### PR TITLE
Fix [New Feature Set] Tooltip icon is overlapping the input

### DIFF
--- a/src/common/DatePicker/datePicker.scss
+++ b/src/common/DatePicker/datePicker.scss
@@ -7,7 +7,6 @@
 
   .date-picker__input-wrapper {
     position: relative;
-    margin-right: 22px;
 
     .date-picker__input {
       &_empty {

--- a/src/common/TimePicker/timePicker.scss
+++ b/src/common/TimePicker/timePicker.scss
@@ -7,5 +7,11 @@
     &__label {
       text-transform: none;
     }
+
+    &__wrapper {
+      input {
+        padding: 0 16px;
+      }
+    }
   }
 }


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3634

![Screenshot from 2023-03-21 13-24-04](https://user-images.githubusercontent.com/109525572/226592252-bada1d1e-504d-432b-8a38-ebea630c5994.png)

I also added padding to the TimePicker component:
![Screenshot from 2023-03-21 13-20-26](https://user-images.githubusercontent.com/109525572/226592010-3dd5b628-32f1-4ceb-a695-3a2755e86fd8.png)
